### PR TITLE
Draft: entity cleanup

### DIFF
--- a/simulator-starter/src/main/java/org/citrusframework/simulator/controller/ActivityController.java
+++ b/simulator-starter/src/main/java/org/citrusframework/simulator/controller/ActivityController.java
@@ -16,7 +16,10 @@
 
 package org.citrusframework.simulator.controller;
 
+import java.time.Instant;
+import java.util.Collection;
 import org.citrusframework.simulator.model.ScenarioExecution;
+import org.citrusframework.simulator.model.ScenarioExecution.Status;
 import org.citrusframework.simulator.model.ScenarioExecutionFilter;
 import org.citrusframework.simulator.service.ActivityService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,9 +29,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.time.Instant;
-import java.util.Collection;
 
 @RestController
 @RequestMapping("api/activity")
@@ -59,7 +59,7 @@ public class ActivityController {
 
     @RequestMapping(method = RequestMethod.GET, value = "/status/{status}")
     public Collection<ScenarioExecution> getScenarioExecutionsByStatus(@PathVariable("status") String status) {
-        return activityService.getScenarioExecutionsByStatus(ScenarioExecution.Status.valueOf(status));
+        return activityService.getScenarioExecutionsByStatus(Status.valueOf(status));
     }
 
     @RequestMapping(method = RequestMethod.GET, value = "/{id}")

--- a/simulator-starter/src/main/java/org/citrusframework/simulator/model/MessageHeader.java
+++ b/simulator-starter/src/main/java/org/citrusframework/simulator/model/MessageHeader.java
@@ -23,8 +23,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
-
 import java.io.Serial;
 import java.io.Serializable;
 
@@ -40,13 +40,16 @@ public class MessageHeader extends AbstractAuditingEntity<MessageHeader, Long> i
     private static final long serialVersionUID = 2L;
 
     @Id
+    @Column(nullable = false, updatable = false)
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long headerId;
 
-    @Column(nullable = false)
+    @NotEmpty
+    @Column(nullable = false, updatable = false)
     private String name;
 
-    @Column(nullable = false, name = "`value`")
+    @NotEmpty
+    @Column(name = "header_value", nullable = false, updatable = false)
     private String value;
 
     @NotNull
@@ -56,6 +59,7 @@ public class MessageHeader extends AbstractAuditingEntity<MessageHeader, Long> i
     private Message message;
 
     public MessageHeader() {
+        // Hibernate constructor
     }
 
     public MessageHeader(String name, String value) {
@@ -65,10 +69,6 @@ public class MessageHeader extends AbstractAuditingEntity<MessageHeader, Long> i
 
     public Long getHeaderId() {
         return headerId;
-    }
-
-    public void setHeaderId(Long headerId) {
-        this.headerId = headerId;
     }
 
     public String getName() {
@@ -102,7 +102,6 @@ public class MessageHeader extends AbstractAuditingEntity<MessageHeader, Long> i
                 ", createdDate='" + getCreatedDate() + "'" +
                 ", name='" + getName() + "'" +
                 ", value='" + getValue() + "'" +
-                ", message='" + getMessage() + "'" +
-                '}';
+                "}";
     }
 }

--- a/simulator-starter/src/main/java/org/citrusframework/simulator/model/ScenarioAction.java
+++ b/simulator-starter/src/main/java/org/citrusframework/simulator/model/ScenarioAction.java
@@ -23,7 +23,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
-
+import jakarta.validation.constraints.NotEmpty;
 import java.io.Serial;
 import java.io.Serializable;
 import java.time.Instant;
@@ -38,12 +38,15 @@ public class ScenarioAction implements Serializable {
     private static final long serialVersionUID = 2L;
 
     @Id
+    @Column(nullable = false, updatable = false)
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long actionId;
 
-    @Column(nullable = false)
+    @NotEmpty
+    @Column(nullable = false, updatable = false)
     private String name;
 
+    @Column(nullable = false, updatable = false)
     private Instant startDate;
 
     private Instant endDate;
@@ -54,10 +57,6 @@ public class ScenarioAction implements Serializable {
 
     public Long getActionId() {
         return actionId;
-    }
-
-    public void setActionId(Long actionId) {
-        this.actionId = actionId;
     }
 
     public String getName() {
@@ -99,7 +98,6 @@ public class ScenarioAction implements Serializable {
                 ", name='" + getName() + "'" +
                 ", startDate='" + getStartDate() + "'" +
                 ", endDate='" + getEndDate() + "'" +
-                ", scenarioExecution='" + getScenarioExecution() + "'" +
-                '}';
+                "}";
     }
 }

--- a/simulator-starter/src/main/java/org/citrusframework/simulator/model/ScenarioExecutionFilter.java
+++ b/simulator-starter/src/main/java/org/citrusframework/simulator/model/ScenarioExecutionFilter.java
@@ -1,12 +1,39 @@
 package org.citrusframework.simulator.model;
 
-import lombok.Data;
+import java.util.Arrays;
+import org.citrusframework.simulator.model.ScenarioExecution.Status;
 
 /**
  * Filter for filtering {@link Message}s
  */
-@Data
 public class ScenarioExecutionFilter extends MessageFilter {
+
     private String scenarioName;
-    private ScenarioExecution.Status[] executionStatus;
+    private Integer[] executionStatus;
+
+    public String getScenarioName() {
+        return scenarioName;
+    }
+
+    public void setScenarioName(String scenarioName) {
+        this.scenarioName = scenarioName;
+    }
+
+    public Status[] getExecutionStatus() {
+        if (executionStatus == null || executionStatus.length == 0) {
+            return new Status[0];
+        }
+
+        return Arrays.stream(executionStatus)
+            .map(Status::fromId)
+            .toList()
+            .toArray(new Status[executionStatus.length]);
+    }
+
+    public void setExecutionStatus(Status[] executionStatus) {
+        this.executionStatus = Arrays.stream(executionStatus)
+            .map(Status::getId)
+            .toList()
+            .toArray(new Integer[0]);
+    }
 }

--- a/simulator-starter/src/main/java/org/citrusframework/simulator/model/ScenarioParameter.java
+++ b/simulator-starter/src/main/java/org/citrusframework/simulator/model/ScenarioParameter.java
@@ -16,13 +16,19 @@
 
 package org.citrusframework.simulator.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import jakarta.persistence.*;
-
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Transient;
+import jakarta.validation.constraints.NotEmpty;
 import java.io.Serial;
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -35,17 +41,22 @@ public class ScenarioParameter extends AbstractAuditingEntity<ScenarioParameter,
     private static final long serialVersionUID = 2L;
 
     @Id
+    @Column(nullable = false, updatable = false)
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long parameterId;
 
-    @Column(nullable = false)
+    @NotEmpty
+    @Column(nullable = false, updatable = false)
     private String name;
 
-    @Column(nullable = false)
-    private ControlType controlType;
+    /**
+     * Actual control type as a numerical representation of {@link ControlType}
+     */
+    @Column(nullable = false, updatable = false)
+    private Integer controlType;
 
     @Lob
-    @Column(columnDefinition = "CLOB", name = "`value`")
+    @Column(columnDefinition = "CLOB", name = "parameter_value", nullable = false, updatable = false)
     private String value;
 
     @ManyToOne
@@ -61,10 +72,6 @@ public class ScenarioParameter extends AbstractAuditingEntity<ScenarioParameter,
 
     public Long getParameterId() {
         return parameterId;
-    }
-
-    public void setParameterId(Long parameterId) {
-        this.parameterId = parameterId;
     }
 
     public String getLabel() {
@@ -92,11 +99,11 @@ public class ScenarioParameter extends AbstractAuditingEntity<ScenarioParameter,
     }
 
     public ControlType getControlType() {
-        return controlType;
+        return ControlType.fromId(controlType);
     }
 
     public void setControlType(ControlType controlType) {
-        this.controlType = controlType;
+        this.controlType = controlType.id;
     }
 
     public String getValue() {
@@ -126,21 +133,35 @@ public class ScenarioParameter extends AbstractAuditingEntity<ScenarioParameter,
     @Override
     public String toString() {
         return "ScenarioParameter{" +
-                ", parameterId='" + getParameterId() +
-                ", createdDate='" + getCreatedDate() +
-                ", name='" + getName() + '\'' +
-                ", controlType='" + getControlType() +
-                ", value='" + getValue() + '\'' +
-                ", options='" + getScenarioExecution() +
-                ", required='" + isRequired() +
-                ", label='" + getLabel() +
-                ", options='" + getOptions() +
-                '}';
+                ", parameterId='" + getParameterId() + "'" +
+                ", createdDate='" + getCreatedDate() + "'" +
+                ", name='" + getName() + "'" + "'" +
+                ", controlType='" + getControlType() + "'" +
+                ", value='" + getValue() + "'" +
+                ", required='" + isRequired() + "'" +
+                ", label='" + getLabel() + "'" +
+                "}";
     }
 
     public enum ControlType {
-        TEXTBOX,
-        TEXTAREA,
-        DROPDOWN
+
+        UNKNOWN(0), TEXTBOX(1), TEXTAREA(2), DROPDOWN(3);
+
+        private final int id;
+
+        ControlType(int id) {
+            this.id = id;
+        }
+
+        public int getId() {
+            return id;
+        }
+
+        public static ControlType fromId(int id) {
+            return Arrays.stream(values())
+                .filter(controlType -> controlType.id == id)
+                .findFirst()
+                .orElse(ControlType.UNKNOWN);
+        }
     }
 }

--- a/simulator-starter/src/main/java/org/citrusframework/simulator/model/ScenarioParameterOption.java
+++ b/simulator-starter/src/main/java/org/citrusframework/simulator/model/ScenarioParameterOption.java
@@ -52,8 +52,8 @@ public class ScenarioParameterOption implements Serializable {
     @Override
     public String toString() {
         return "ScenarioParameterOption{" +
-                "key='" + key + '\'' +
-                ", value='" + value + '\'' +
-                '}';
+                "key='" + key + "'" +
+                ", value='" + value + "'" +
+                "}";
     }
 }

--- a/simulator-starter/src/main/java/org/citrusframework/simulator/model/TestParameter.java
+++ b/simulator-starter/src/main/java/org/citrusframework/simulator/model/TestParameter.java
@@ -16,6 +16,7 @@
 
 package org.citrusframework.simulator.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.EmbeddedId;
@@ -64,6 +65,7 @@ public class TestParameter extends AbstractAuditingEntity<TestParameter, TestPar
     @ManyToOne
     @MapsId("testResultId")
     @JoinColumn(name = "test_result_id")
+    @JsonIgnoreProperties(value = { "testParameters" }, allowSetters = true)
     private TestResult testResult;
 
     /**
@@ -96,6 +98,14 @@ public class TestParameter extends AbstractAuditingEntity<TestParameter, TestPar
 
     public TestResult getTestResult() {
         return testResult;
+    }
+
+    @Override
+    public String toString() {
+        return "TestParameter{" +
+            "key='" + getKey() + "'" +
+            "value='" + getValue() + "'" +
+            "}";
     }
 
     /**

--- a/simulator-starter/src/main/java/org/citrusframework/simulator/model/TestResult.java
+++ b/simulator-starter/src/main/java/org/citrusframework/simulator/model/TestResult.java
@@ -24,7 +24,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.validation.constraints.NotEmpty;
-
 import java.io.Serial;
 import java.io.Serializable;
 import java.util.Arrays;
@@ -60,7 +59,7 @@ public class TestResult extends AbstractAuditingEntity<TestResult, Long> impleme
      * Actual result as a numerical representation of {@link Status}
      */
     @Column(nullable = false, updatable = false)
-    private int status;
+    private Integer status;
 
     /**
      * Name of the test
@@ -129,10 +128,7 @@ public class TestResult extends AbstractAuditingEntity<TestResult, Long> impleme
     }
 
     public Status getStatus() {
-        return Arrays.stream(Status.values())
-                .filter(result -> result.id == status)
-                .findFirst()
-                .orElse(Status.UNKNOWN);
+        return Status.fromId(status);
     }
 
     public String getTestName() {
@@ -167,6 +163,20 @@ public class TestResult extends AbstractAuditingEntity<TestResult, Long> impleme
                 .id;
     }
 
+    @Override
+    public String toString() {
+        return "TestResult{" +
+            "id='" + getId() + "'" +
+            ", createdDate='" + getCreatedDate() + "'" +
+            ", status='" + getStatus() + "'" +
+            ", testName='" + getTestName() + "'" +
+            ", className='" + getClassName() + "'" +
+            ", errorMessage='" +getErrorMessage() + "'" +
+            ", failureStack='" +getFailureStack() + "'" +
+            ", failureType='" +getFailureType() + "'" +
+            "}";
+    }
+
     public enum Status {
 
         UNKNOWN(0), SUCCESS(1), FAILURE(2), SKIP(3);
@@ -175,6 +185,17 @@ public class TestResult extends AbstractAuditingEntity<TestResult, Long> impleme
 
         Status(int i) {
             this.id = i;
+        }
+
+        public int getId() {
+            return id;
+        }
+
+        public static Status fromId(int id) {
+            return Arrays.stream(values())
+                .filter(status -> status.id == id)
+                .findFirst()
+                .orElse(Status.UNKNOWN);
         }
     }
 }

--- a/simulator-starter/src/main/java/org/citrusframework/simulator/repository/AbstractRepository.java
+++ b/simulator-starter/src/main/java/org/citrusframework/simulator/repository/AbstractRepository.java
@@ -36,11 +36,11 @@ public abstract class AbstractRepository {
                                          List<Predicate> predicates) {
 
         if (!filter.getDirectionInbound()) {
-            predicates.add(criteriaBuilder.notEqual(path.get("direction"), Direction.INBOUND));
+            predicates.add(criteriaBuilder.notEqual(path.get("direction"), Direction.INBOUND.getId()));
         }
 
         if (!filter.getDirectionOutbound()) {
-            predicates.add(criteriaBuilder.notEqual(path.get("direction"), Direction.OUTBOUND));
+            predicates.add(criteriaBuilder.notEqual(path.get("direction"), Direction.OUTBOUND.getId()));
         }
     }
 

--- a/simulator-starter/src/main/java/org/citrusframework/simulator/repository/ScenarioExecutionRepositoryImpl.java
+++ b/simulator-starter/src/main/java/org/citrusframework/simulator/repository/ScenarioExecutionRepositoryImpl.java
@@ -1,5 +1,6 @@
 package org.citrusframework.simulator.repository;
 
+import ch.qos.logback.classic.spi.Configurator.ExecutionStatus;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -73,8 +74,8 @@ public class ScenarioExecutionRepositoryImpl extends AbstractRepository implemen
     private void addScenarioStatusPredicate(ScenarioExecutionFilter filter, CriteriaBuilder criteriaBuilder,
             Root<ScenarioExecution> scenarioExecution, List<Predicate> predicates) {
         if (filter.getExecutionStatus() != null && filter.getExecutionStatus().length>0) {
-            CriteriaBuilder.In<Status> inClause = criteriaBuilder.in(scenarioExecution.get("status"));
-            Arrays.stream(filter.getExecutionStatus()).forEach(inClause::value);
+            CriteriaBuilder.In<Integer> inClause = criteriaBuilder.in(scenarioExecution.get("status"));
+            Arrays.stream(filter.getExecutionStatus()).map(Status::getId).forEach(inClause::value);
             predicates.add(inClause);
         }
     }

--- a/simulator-starter/src/test/java/org/citrusframework/simulator/service/ScenarioExecutionRepositoryTest.java
+++ b/simulator-starter/src/test/java/org/citrusframework/simulator/service/ScenarioExecutionRepositoryTest.java
@@ -87,7 +87,7 @@ public class ScenarioExecutionRepositoryTest extends AbstractTestNGSpringContext
         String inUid = UUID.randomUUID().toString();
         String outUid = UUID.randomUUID().toString();
 
-        String uniqueScenarioName = TEST_SCENARIO + UUID.randomUUID().toString();
+        String uniqueScenarioName = TEST_SCENARIO + UUID.randomUUID();
         createTestScenarioExecution(uniqueScenarioName, inUid + 1, PAYLOAD, outUid + 1, PAYLOAD, Status.SUCCESS);
         Long failedScenarioExecutionId = createTestScenarioExecution(uniqueScenarioName, inUid + 2, PAYLOAD, outUid + 2, PAYLOAD, Status.FAILED);
 
@@ -246,7 +246,7 @@ public class ScenarioExecutionRepositoryTest extends AbstractTestNGSpringContext
         ScenarioExecution scenarioExecution = activityService.createExecutionScenario(scenarioName, Collections.emptySet());
         activityService.saveScenarioMessage(scenarioExecution.getExecutionId(), Direction.INBOUND, inPayload, inUid, inHeaders);
 
-        Map<String, Object> outHeaders = new HashMap<String, Object>();
+        Map<String, Object> outHeaders = new HashMap<>();
         outHeaders.put(OUT_HEADER_NAME1, outUid);
         outHeaders.put(OUT_HEADER_NAME2, outUid + "_2");
         activityService.saveScenarioMessage(scenarioExecution.getExecutionId(), Direction.OUTBOUND, outPayload, outUid, outHeaders);


### PR DESCRIPTION
cleanup entites in `org.citrusframework.simulator.model` - making them "more secure" or minimal changeable.